### PR TITLE
fix: Apply fetchpriority to proper element, <Link />.

### DIFF
--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -149,7 +149,6 @@ function Image(props: ImageProps) {
       ref={imageRef}
       className={handles.imageElement}
       loading={loading}
-      fetchpriority={fetchpriority}
       {...(experimentalSetExplicitDimensions && explicitDimensionsAreAvailable
         ? {
             width: widthWithoutUnits ?? undefined,
@@ -196,6 +195,7 @@ function Image(props: ImageProps) {
     // knowing this, it seems good to disable the anchor-is-valid rule.
     // eslint-disable-next-line jsx-a11y/anchor-is-valid
     <Link
+      fetchpriority={fetchpriority}
       to={typeof formattedLink === 'string' ? formattedLink : ''}
       title={typeof formattedTitle === 'string' ? formattedTitle : ''}
       rel={link.attributeNofollow ? 'nofollow' : ''}


### PR DESCRIPTION
#### What problem is this solving?
fetchPriority attribute is doing nothing since it's applied to an <img /> element instead of the <Link /> anchor.

<!--- What is the motivation and context for this change? -->
Fix bug in component.

#### How to test it?
1. Render an image with an href so it gets wrapped around an anchor.
2. Check rendered anchor has the attribute applied.

#### Related to / Depends on
vtex.render-runtime because <Link /> comes from there but I already checked it takes props by destructuring so this will work without changing anything there.